### PR TITLE
Add Threads post scraping script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.session.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# gpt
+# Threads Scraper
+
+This repository contains a simple Python script for collecting posts from a public user on [Threads](https://www.threads.net/). The script uses the `threads-api` package and does not require authentication for scraping public accounts.
+
+## Requirements
+
+- Python 3.11
+- `threads-api` and its dependencies
+
+The required libraries can be installed with `pip`:
+
+```bash
+pip install threads-api cryptography colorama instagrapi==1.19.8 Pillow
+```
+
+## Usage
+
+Run the scraper with a Threads username. Optionally provide an output filename (defaults to `<username>_threads.json`).
+
+```bash
+python threads_scraper.py <username> [output_file]
+```
+
+Example:
+
+```bash
+python threads_scraper.py zuck zuck_posts.json
+```
+
+The script writes the retrieved threads data as JSON.

--- a/threads_scraper.py
+++ b/threads_scraper.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+import sys
+from threads_api.src.threads_api import ThreadsAPI
+
+async def fetch_threads(username: str, output: str):
+    api = ThreadsAPI()
+    user_id = await api.get_user_id_from_username(username)
+    if not user_id:
+        raise SystemExit(f"User '{username}' not found")
+    threads = await api.get_user_threads(user_id)
+    with open(output, 'w', encoding='utf-8') as f:
+        json.dump(threads.dict(), f, ensure_ascii=False, indent=2)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python threads_scraper.py <username> [output_file]')
+        raise SystemExit(1)
+    username = sys.argv[1].lstrip('@')
+    output = sys.argv[2] if len(sys.argv) > 2 else f'{username}_threads.json'
+    asyncio.run(fetch_threads(username, output))
+


### PR DESCRIPTION
## Summary
- add `threads_scraper.py` to fetch posts from a public Threads user
- document how to install requirements and run the script in `README.md`
- ignore `.session.json` file generated by the library

## Testing
- `python threads_scraper.py zuck zuck_posts.json` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68417362639c83209ffcee83693a7464